### PR TITLE
UI overhaul with way less 'levels'

### DIFF
--- a/ui/rootui.go
+++ b/ui/rootui.go
@@ -13,13 +13,14 @@ func init() {
 	ApiKeyItem.Value = state.State.AlchApiKey
 }
 
+var SettingsItem = &Item{Label: settingsIcon + "  Settings", Details: "Paymasters, Signers, ChainID, ..."}
+var UserOpItem = &Item{Label: userOpsIcon + " User Operations", Details: "Manage User Operations"}
+var AbisItem = &Item{Label: abisIcon + " ABIs", Details: "Manage ABIs"}
+
 var PaymasterItem = &Item{Label: "Paymaster", Details: "Manage Paymaster settings"}
-var UserOpItem = &Item{Label: "User Operations", Details: "Manage User Operations"}
-var AbisItem = &Item{Label: "ABIs", Details: "Manage ABIs"}
 var SignerItem = &Item{Label: "Signer", Details: "Manage Signer settings"}
 var EntryPointItem = &Item{Label: "Entrypoint", Details: "Set Entrypoint"}
 var ApiKeyItem = &Item{Label: "Alchemy API Key", Details: "Set Alchemy API Key"}
-var SettingsItem = &Item{Label: "Settings", Details: "Paymasters, Signers, ChainID, ..."}
 
 func RootUI() {
 	items := []*Item{

--- a/ui/signui.go
+++ b/ui/signui.go
@@ -26,7 +26,7 @@ var PreHashV7Item = &Item{Label: "Pre Hash_v7", Details: "Hash of an encoded use
 var PreHashV6Item = &Item{Label: "Pre Hash_v6", Details: "Hash of an encoded user operation"}
 var EncodedBytesItem = &Item{Label: "Encoded Bytes", Details: "Encoded bytes of the user operation"}
 
-func GetHashUI(usop *userop.UserOperation) (sig []byte, err error) {
+func UtilsUI(usop *userop.UserOperation) (sig []byte, err error) {
 	var SignItem = &Item{Label: "Sign", Details: "Sign the user operation"}
 	prompt := promptui.Select{
 		Label: "Select an option",
@@ -76,7 +76,6 @@ func GetHashUI(usop *userop.UserOperation) (sig []byte, err error) {
 				hash, err = userop.GetUserOpHashV6(usop, EntryPoint, ChainID)
 				fmt.Println("Signing using v6 hashes")
 			} else {
-
 				hash, err = userop.GetUserOpHashV7(usop.Pack(), EntryPoint, ChainID)
 				fmt.Println("Signing using v7 hashes")
 			}
@@ -160,7 +159,7 @@ func SetSignatureUI(userop *userop.UserOperation) (calldata []byte, err error) {
 			}
 			return it.Value.([]byte), err
 		case UseSignerItem.Label:
-			return GetHashUI(userop)
+			return UtilsUI(userop)
 		default:
 			fmt.Println("Unreachable reached:", sel)
 		}

--- a/ui/uitems.go
+++ b/ui/uitems.go
@@ -15,7 +15,8 @@ type Item struct {
 	Label              string
 	Value              interface{}
 	Details            string
-	DisplayValueString string //could be a function, but I am lazy
+	DisplayValueString string // could be a function, but I am lazy
+	IsUserOp           bool   // To show them in a different color now that there are less menus
 }
 
 func (i *Item) DisplayValue() string {
@@ -89,12 +90,16 @@ func (i *Item) String() string {
 
 const unicorn = "\U0001F984"
 
+const settingsIcon = "\U0001F6E0"
+const userOpsIcon = "\U0001F464"
+const abisIcon = "\U0001F517"
+
 const (
 	EXIT = "EXIT"
 	BACK = "BACK"
 )
 
-// Rewrite the above as variable instantiation witt OK=&Item{Label: "OK"} pattern
+// Rewrite the above as variable instantiation with OK=&Item{Label: "OK"} pattern
 var OK = &Item{Label: "OK", Details: "Confirm and proceed"}
 var Back = &Item{Label: BACK, Details: "Go back to previous menu"}
 var Exit = &Item{Label: EXIT, Details: "Exit the program"}
@@ -102,8 +107,8 @@ var Set = &Item{Label: "Set", Details: "Set the value"}
 
 var ItemTemplate = &promptui.SelectTemplates{
 	Label:    "{{ . | bold | cyan}}",
-	Inactive: `{{if eq .Label "BACK"}}{{.Label | yellow}}{{else if eq .Label "EXIT"}}{{.Label | red}}{{else if eq .Label "Set"}}{{.Label | green}}{{else}}{{ .Label }}{{with .DisplayValue}}: {{.}}{{end}}{{end}}`,
-	Active:   `{{if eq .Label "BACK"}}{{.Label | yellow | bold | underline}}{{else if eq .Label "EXIT"}}{{.Label | red | bold | underline}}{{else if eq .Label "Set"}}{{.Label | green | bold | underline}}{{else}}{{ .Label | bold | underline }}{{with .DisplayValue}}: {{. | bold}}{{end}}{{end}}`,
+	Inactive: `{{if eq .IsUserOp true}}{{.Label | magenta}}{{else if eq .Label "BACK"}}{{.Label | yellow}}{{else if eq .Label "EXIT"}}{{.Label | red}}{{else if or (eq .Label "Set") (eq .Label "Export User Operation")}}{{.Label | green}}{{else if eq .Label "Utils: hashes and signatures"}}{{.Label | faint}}{{else}}{{ .Label }}{{with .DisplayValue}}: {{.}}{{end}}{{end}}`,
+	Active:   `{{if eq .IsUserOp true}}{{.Label | magenta | bold | underline}}{{else if eq .Label "BACK"}}{{.Label | yellow | bold | underline}}{{else if eq .Label "EXIT"}}{{.Label | red | bold | underline}}{{else if or (eq .Label "Set") (eq .Label "Export User Operation")}}{{.Label | green | bold | underline}}{{else if eq .Label "Utils: hashes and signatures"}}{{.Label | faint | bold | underline}}{{else}}{{ .Label | bold | underline }}{{with .DisplayValue}}: {{. | bold}}{{end}}{{end}}`,
 	Selected: "{{. | faint}}",
 	Details:  "{{ .Details | faint }}",
 }


### PR DESCRIPTION
With the previous UI, it was cumbersome to edit a user operation. The flow was:
User Operations -> Select User Operation -> UserOp name -> Work on User Operation -> User Operation Content

Now its only two steps:
User Operations -> UserOp name

I "combined" several menus into one, and added some colors for better readability.